### PR TITLE
Fixes command line example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once you have a data set, you can run lenskit-hello through your IDE, or from th
 as follows:
 
     $ ./gradlew build
-    $ /bin/sh target/hello/bin/lenskit-hello.sh ml100k/u.data <userid>
+    $ /bin/sh build/install/lenskit-algorithm-example/bin/lenskit-algorithm-example ml100k/u.data <userid>
 
 The default delimiter is the tab character.
 


### PR DESCRIPTION
The path for the shell script in README used the path to the script in [lenskit/lenskit-hello](https://github.com/lenskit/lenskit-hello). This is a very small change, but it should save people some confusion.